### PR TITLE
Graphics!

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Compare a CodeQL SARIF results file to a security standard CWE list and annotate
 - Any XML file can be provided as an alternative, with the option to provide an XPath query that identifies the CWE ID values to use in the conparison
 - Tag value is configurable
 
+This supports the ability to filter the Security dashboards by `tag`
+<img width="783" alt="filter the Security dashboards by tag" src="https://github.com/advanced-security/codeql-sarif-security-standard-annotator/assets/1760475/ca1b5519-2a9c-4f03-8dca-4f03bc6fbc05">
+<br/>
+<br/>
+As well as displaying this information along side the Code scanning alert
+<img width="614" alt="displaying this information along side the Code scanning alert" src="https://github.com/advanced-security/codeql-sarif-security-standard-annotator/assets/1760475/30b1c71a-8ee0-4c49-acbf-2161df7c7582">
+
 ## Usage in GitHub Actions
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Compare a CodeQL SARIF results file to a security standard CWE list and annotate
 
 This supports the ability to filter the Security dashboards by `tag`
 <img width="783" alt="filter the Security dashboards by tag" src="https://github.com/advanced-security/codeql-sarif-security-standard-annotator/assets/1760475/ca1b5519-2a9c-4f03-8dca-4f03bc6fbc05">
-<br/>
-<br/>
+<br/><br/>
 As well as displaying this information along side the Code scanning alert
 <img width="614" alt="displaying this information along side the Code scanning alert" src="https://github.com/advanced-security/codeql-sarif-security-standard-annotator/assets/1760475/30b1c71a-8ee0-4c49-acbf-2161df7c7582">
 


### PR DESCRIPTION
This pull request includes a change to the `README.md` file of the project.  It includes two images that illustrate the new feature, one showing how to filter the Security dashboards by `tag` and another one displaying this information alongside the Code scanning alert.

[Rendered README.MD](https://github.com/advanced-security/codeql-sarif-security-standard-annotator/blob/fffdb1336f12dc5f7a18efe3878eaf7cf905a861/README.md#codeql-sarif-security-standard-annotator)